### PR TITLE
Fix product image upload in admin

### DIFF
--- a/FIX_IMAGE_UPLOAD_ISSUE.md
+++ b/FIX_IMAGE_UPLOAD_ISSUE.md
@@ -1,0 +1,65 @@
+# תיקון בעיית העלאת תמונות בעמוד האדמין
+
+## הבעיה
+לא ניתן להעלות תמונות בעמוד האדמין כי ה-bucket "product-images" לא קיים ב-Supabase Storage.
+
+## הפתרון
+
+### שלב 1: כניסה ל-Supabase Dashboard
+1. היכנס לכתובת: https://supabase.com/dashboard/project/oywfddfwttncjayglvoy
+2. היכנס עם פרטי המשתמש שלך
+
+### שלב 2: יצירת Storage Bucket
+
+#### אפשרות א' - דרך ה-UI (מומלץ):
+1. בתפריט הצדדי, לחץ על **Storage**
+2. לחץ על כפתור **"New bucket"**
+3. הזן את הפרטים הבאים:
+   - **Name**: `product-images`
+   - **Public bucket**: ✅ סמן את התיבה (חשוב!)
+   - **File size limit**: 10MB
+   - **Allowed MIME types**: `image/jpeg,image/png,image/gif,image/webp`
+4. לחץ על **"Create bucket"**
+
+#### אפשרות ב' - דרך SQL Editor:
+1. בתפריט הצדדי, לחץ על **SQL Editor**
+2. העתק והדבק את התוכן מהקובץ `create-storage-bucket.sql`
+3. לחץ על **"Run"**
+
+### שלב 3: אימות שה-bucket נוצר
+1. חזור ל-**Storage** בתפריט הצדדי
+2. וודא שאתה רואה bucket בשם `product-images`
+3. לחץ עליו וודא שהוא מוגדר כ-Public
+
+### שלב 4: בדיקת העלאת תמונות באפליקציה
+1. פתח את האפליקציה בכתובת: http://localhost:3000
+2. לחץ על שם החנות בכותרת
+3. הזן סיסמה: `admin123`
+4. לחץ על **"הוסף מוצר"**
+5. נסה להעלות תמונה בחלק של "תמונות המוצר"
+
+## בדיקות נוספות
+
+### בדיקת חיבור ל-Storage
+הרץ בטרמינל:
+```bash
+node test-storage.js
+```
+
+הפלט הצפוי:
+- `Available buckets: ['product-images']`
+- `Product-images bucket exists: true`
+- `Test file uploaded successfully`
+
+### פתרון בעיות נפוצות
+
+#### אם עדיין יש שגיאת RLS:
+1. ב-Supabase Dashboard, לך ל-**Authentication** > **Policies**
+2. וודא שה-policies עבור `storage.objects` מאפשרות גישה ציבורית ל-bucket `product-images`
+
+#### אם יש שגיאת CORS:
+1. ב-Supabase Dashboard, לך ל-**Settings** > **API**
+2. בחלק של CORS, הוסף את `http://localhost:3000` לרשימת הדומיינים המורשים
+
+## סיכום
+הבעיה נגרמה מכך שה-bucket `product-images` לא היה קיים ב-Supabase Storage. לאחר יצירת ה-bucket עם הרשאות ציבוריות, העלאת התמונות אמורה לעבוד כראוי.

--- a/create-storage-bucket.sql
+++ b/create-storage-bucket.sql
@@ -1,0 +1,50 @@
+-- First, ensure the storage schema exists
+CREATE SCHEMA IF NOT EXISTS storage;
+
+-- Create the product-images bucket
+INSERT INTO storage.buckets (id, name, public, avif_autodetection, file_size_limit, allowed_mime_types)
+VALUES (
+  'product-images',
+  'product-images', 
+  true,  -- Make it public
+  false, -- No AVIF auto-detection
+  10485760, -- 10MB limit
+  ARRAY['image/jpeg', 'image/png', 'image/gif', 'image/webp']::text[]
+)
+ON CONFLICT (id) DO UPDATE SET
+  public = true,
+  file_size_limit = 10485760,
+  allowed_mime_types = ARRAY['image/jpeg', 'image/png', 'image/gif', 'image/webp']::text[];
+
+-- Drop existing policies if they exist
+DROP POLICY IF EXISTS "Allow public uploads" ON storage.objects;
+DROP POLICY IF EXISTS "Allow public read access" ON storage.objects;
+DROP POLICY IF EXISTS "Allow public updates" ON storage.objects;
+DROP POLICY IF EXISTS "Allow public deletes" ON storage.objects;
+
+-- Create storage policies for the product-images bucket
+-- Allow anyone to upload
+CREATE POLICY "Allow public uploads to product-images"
+ON storage.objects FOR INSERT 
+WITH CHECK (bucket_id = 'product-images');
+
+-- Allow anyone to read/download
+CREATE POLICY "Allow public read access to product-images"
+ON storage.objects FOR SELECT 
+USING (bucket_id = 'product-images');
+
+-- Allow anyone to update
+CREATE POLICY "Allow public updates to product-images"
+ON storage.objects FOR UPDATE 
+USING (bucket_id = 'product-images')
+WITH CHECK (bucket_id = 'product-images');
+
+-- Allow anyone to delete
+CREATE POLICY "Allow public deletes from product-images"
+ON storage.objects FOR DELETE 
+USING (bucket_id = 'product-images');
+
+-- Verify the bucket was created
+SELECT id, name, public, file_size_limit, allowed_mime_types 
+FROM storage.buckets 
+WHERE id = 'product-images';


### PR DESCRIPTION
Add instructions and an SQL script to configure Supabase Storage for image uploads.

The image upload functionality in the admin panel was failing because the 'product-images' bucket was missing in Supabase Storage, and the necessary Row Level Security (RLS) policies were not in place. This PR provides a detailed guide (`FIX_IMAGE_UPLOAD_ISSUE.md`) and an SQL script (`create-storage-bucket.sql`) for the user to set up the bucket and its permissions in their Supabase dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-b67ec63b-dda2-486a-949e-3982c6712c06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b67ec63b-dda2-486a-949e-3982c6712c06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>